### PR TITLE
Updated to latest jetty version to skip running as root

### DIFF
--- a/hystrix-dashboard/pom.xml
+++ b/hystrix-dashboard/pom.xml
@@ -29,7 +29,7 @@
   <description>Dashboard for visualization of Hystrix streams</description>
 
   <properties>
-    <docker.from>docker.io/fabric8/jetty-9:1.0.0</docker.from>
+    <docker.from>docker.io/fabric8/jetty-9:1.2.1</docker.from>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
   </properties>

--- a/hystrix-dashboard/pom.xml
+++ b/hystrix-dashboard/pom.xml
@@ -86,6 +86,7 @@
               <build>
                 <from>${docker.from}</from>
                 <assembly>
+                  <basedir>/deployments</basedir>
                   <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
                 </assembly>
               </build>

--- a/turbine-server/pom.xml
+++ b/turbine-server/pom.xml
@@ -28,7 +28,7 @@
   <description>Turbine server with the Kubernetes discovery module pre-installed and pre-configured</description>
 
   <properties>
-    <docker.from>docker.io/fabric8/jetty-9:1.0.0</docker.from>
+    <docker.from>docker.io/fabric8/jetty-9:1.2.1</docker.from>
     <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
   </properties>


### PR DESCRIPTION
Current images for hystrix-dashboard and turbine-server on DockerHub are based on jetty 1.0.0 image that used to run as root. Therefore the current images must run privileged. Not all users are admin to their environments and they won't be able to deploy these images in that case.

The jetty base image is updated to the latest version (1.2.1) which doesn't run as root and therefore can be deployed as an unprivileged container. 

[1] https://hub.docker.com/r/fabric8/hystrix-dashboard/
[2] https://hub.docker.com/r/fabric8/turbine-server/
[3] https://hub.docker.com/r/fabric8/jetty-9/