### PR TITLE
Spring boot fixes

### DIFF
--- a/examples/hello-world/hello-ribbon-springboot/src/main/java/io/fabric8/kubeflix/examples/hellospringbootribbon/Application.java
+++ b/examples/hello-world/hello-ribbon-springboot/src/main/java/io/fabric8/kubeflix/examples/hellospringbootribbon/Application.java
@@ -18,8 +18,11 @@ package io.fabric8.kubeflix.examples.hellospringbootribbon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableCircuitBreaker
@@ -28,5 +31,10 @@ public class Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
     }
 }

--- a/examples/loanbroker/bank/src/main/java/io/fabric8/kubeflix/examples/loanbroker/bank/Application.java
+++ b/examples/loanbroker/bank/src/main/java/io/fabric8/kubeflix/examples/loanbroker/bank/Application.java
@@ -18,9 +18,12 @@ package io.fabric8.kubeflix.examples.loanbroker.bank;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy(proxyTargetClass = true)
@@ -30,5 +33,10 @@ public class Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <groovy.version>2.4.1</groovy.version>
         <kubernetes-client.version>1.4.14</kubernetes-client.version>
         <mockwebserver.version>0.0.4</mockwebserver.version>
-        <netty.version>4.0.27.Final</netty.version>
+        <netty.version>4.1.4.Final</netty.version>
         <rxjava.version>1.1.9</rxjava.version>
         <rxnetty.version>0.4.18</rxnetty.version>
         <ribbon.version>2.2.0</ribbon.version>


### PR DESCRIPTION
netty.version should be set to 1.4.1.Final, otherwise not all jar files in the WEB-INF/lib and hello-ribbon doesn't run.

Method of initialization of bean RestTemplate should be fixed according of how it has to be used on SpringBoot 1.4.1.RELEASE.