### PR TITLE
NullPointerException while getting list of services has been fixed.

### DIFF
--- a/examples/hello-world/hello-hystrix/src/main/java/io/fabric8/kubeflix/examples/hellohystrix/HelloCommand.java
+++ b/examples/hello-world/hello-hystrix/src/main/java/io/fabric8/kubeflix/examples/hellohystrix/HelloCommand.java
@@ -25,7 +25,7 @@ public class HelloCommand extends HystrixCommand<String> {
 
 
     protected HelloCommand() {
-        super(HystrixCommandGroupKey.Factory.asKey("HelloGroup"));
+        super(HystrixCommandGroupKey.Factory.asKey("HelloRibbonGroup"));
     }
 
     @Override

--- a/ribbon-discovery/src/main/java/io/fabric8/kubeflix/ribbon/KubernetesServerList.java
+++ b/ribbon-discovery/src/main/java/io/fabric8/kubeflix/ribbon/KubernetesServerList.java
@@ -61,6 +61,7 @@ public class KubernetesServerList extends AbstractServerList<Server> implements 
     }
 
     public void initWithNiwsConfig(IClientConfig clientConfig) {
+        this.client = new DefaultKubernetesClient();
         this.clientConfig = clientConfig;
         this.name = clientConfig.getClientName();
         this.namespace = clientConfig.getPropertyAsString(KubernetesConfigKey.Namespace, client.getNamespace());


### PR DESCRIPTION
By default KubernetesServerList() initializes with default constructor and then method initWithNiwsConfig(IClientConfig clientConfig) runs.

Default constructor doesn't initialize this.client that leads to NullPointerException in line 67. This has been fixed.

Also, hellohystrix and helloribbon use different keys and looks like this is a reason why ribbon can't find hello-hystrix command.

cc: @iocanel 